### PR TITLE
Support L5.4 by removing deprecation

### DIFF
--- a/src/Jobs/FlushTagFromFileCacheJob.php
+++ b/src/Jobs/FlushTagFromFileCacheJob.php
@@ -6,9 +6,8 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Contracts\Bus\SelfHandling;
 
-class FlushTagFromFileCacheJob implements ShouldQueue, SelfHandling
+class FlushTagFromFileCacheJob implements ShouldQueue
 {
 	/*
 	|--------------------------------------------------------------------------


### PR DESCRIPTION
This PR adds support for Laravel 5.4 by removing a reference to the deprecated interface `Illuminate\Contracts\Bus\SelfHandling`. I have tested this solution and it works, it's also fully backward compatible.

Resolves issue #4 